### PR TITLE
Add loan request module with document capture workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,67 @@
 # sofomcloud_mobile
 
-A new Flutter project.
+Aplicación móvil desarrollada con Flutter y null‑safety que implementa un flujo de solicitud de préstamos con captura automática de documentos y firma digital.
 
-## Getting Started
+## Requisitos previos
 
-This project is a starting point for a Flutter application.
+- Flutter 3.x y Dart 3.x instalados
+- Dispositivo físico con cámara (probado en OnePlus NE2215 con Android 15)
+- Acceso a Internet para obtener dependencias
 
-A few resources to get you started if this is your first Flutter project:
+## Estructura del proyecto
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+El módulo `loan_request` se encuentra en `lib/app/modules/loan_request` e incluye las siguientes pantallas:
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+1. `/loan/request/start` – inicio del flujo con el botón **Solicitar préstamos**.
+2. `/loan/request/capture-card` – captura de tarjeta.
+3. `/loan/request/capture-ine-front` – INE frente.
+4. `/loan/request/capture-ine-back` – INE reverso.
+5. `/loan/request/capture-doc` – documento adicional.
+6. `/loan/request/sign` – firma con el dedo.
+7. `/loan/request/review` – resumen y envío de la solicitud.
+
+Las imágenes se guardan en el directorio temporal del dispositivo y sus rutas se persisten en el estado global administrado con Riverpod.
+
+### Permisos
+
+- **Android**: se requiere declarar `android.permission.CAMERA` y permisos de almacenamiento en `AndroidManifest.xml`.
+- **iOS**: incluir `NSCameraUsageDescription` y `NSPhotoLibraryAddUsageDescription` en `Info.plist`.
+
+## Ejecución
+
+1. Instalar dependencias:
+
+   ```sh
+   flutter pub get
+   ```
+2. Conectar un dispositivo con depuración USB habilitada.
+3. Ejecutar la aplicación:
+
+   ```sh
+   flutter run
+   ```
+
+Si hay múltiples dispositivos, especifica uno con `flutter run -d <deviceId>`.
+
+> **Nota:** La captura de documentos requiere aceptar los permisos de cámara cuando se soliciten.
+
+## Dependencias principales
+
+- `camera` – captura y vista previa de la cámara.
+- `permission_handler` – solicitud de permisos en tiempo de ejecución.
+- `google_mlkit_document_scanner` o `edge_detection` – detección de documentos.
+- `signature` – captura de firma en pantalla.
+- `riverpod` – manejo de estado global.
+- `http` o `dio` – envío de la solicitud al servicio `https://api.ejemplo.com/loan/request`.
+
+## Desarrollo
+
+Ejecuta los siguientes comandos para mantener la calidad del código:
+
+```sh
+dart format .
+flutter analyze
+```
+
+Las pruebas se deben realizar en un dispositivo físico debido al uso de la cámara.
+

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,8 @@ android {
         applicationId = "com.example.sofomcloud_mobile"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        // ML Kit document scanner requires at least API 21
+        minSdk = 21
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
         android:label="sofomcloud_mobile"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+<key>NSCameraUsageDescription</key>
+<string>Necesitamos acceso a la cámara para capturar documentos.</string>
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>Necesitamos acceso al almacenamiento para guardar los archivos.</string>
 </dict>
 </plist>

--- a/lib/app/modules/loan_request/auto_capture_screen.dart
+++ b/lib/app/modules/loan_request/auto_capture_screen.dart
@@ -1,0 +1,342 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:camera/camera.dart';
+import 'package:edge_detection/edge_detection.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:google_mlkit_document_scanner/google_mlkit_document_scanner.dart';
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'camera_utils.dart';
+
+enum CapturePurpose { cardFront, ineFront, ineBack, docPhoto }
+
+/// Widget that automatically captures a document when a stable rectangle is detected.
+class AutoCaptureScreen extends StatefulWidget {
+  final String title;
+  final CapturePurpose purpose;
+  final void Function(XFile file) onSaved;
+  final String nextRoute;
+  final String? initialPath;
+
+  const AutoCaptureScreen({
+    super.key,
+    required this.title,
+    required this.purpose,
+    required this.onSaved,
+    required this.nextRoute,
+    this.initialPath,
+  });
+
+  @override
+  State<AutoCaptureScreen> createState() => _AutoCaptureScreenState();
+}
+
+class _AutoCaptureScreenState extends State<AutoCaptureScreen> {
+  CameraController? _controller;
+  bool _initialized = false;
+  final DocumentScanner _scanner = DocumentScanner();
+  Rect? _detectedRect;
+  Timer? _stabilityTimer;
+  Timer? _countdownTimer;
+  int? _countdown;
+  XFile? _capturedFile;
+  DateTime _lastDetectionProcess = DateTime.fromMillisecondsSinceEpoch(0);
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    try {
+      final camera = await ensureCameraReady();
+      _controller = CameraController(camera, ResolutionPreset.high, enableAudio: false);
+      await _controller!.initialize();
+      await _controller!.startImageStream(_processCameraImage);
+      if (mounted && widget.initialPath != null) {
+        _capturedFile = XFile(widget.initialPath!);
+      }
+      setState(() => _initialized = true);
+    } catch (_) {
+      // Permission denied or camera unavailable
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    _countdownTimer?.cancel();
+    _stabilityTimer?.cancel();
+    _scanner.close();
+    super.dispose();
+  }
+
+  Future<void> _processCameraImage(CameraImage image) async {
+    // Process only 3 frames per second.
+    if (DateTime.now().difference(_lastDetectionProcess) < const Duration(milliseconds: 300)) {
+      return;
+    }
+    _lastDetectionProcess = DateTime.now();
+    if (_controller == null || !_controller!.value.isStreamingImages) return;
+
+    try {
+      final inputImage = InputImage.fromBytes(
+        bytes: _concatenatePlanes(image.planes),
+        inputImageData: InputImageData(
+          size: Size(image.width.toDouble(), image.height.toDouble()),
+          imageRotation: InputImageRotation.rotation0deg,
+          inputImageFormat: InputImageFormatMethods.fromRawValue(image.format.raw) ??
+              InputImageFormat.nv21,
+          planeData: image.planes
+              .map((plane) => InputImagePlaneMetadata(
+                    bytesPerRow: plane.bytesPerRow,
+                    height: plane.height,
+                    width: plane.width,
+                  ))
+              .toList(),
+        ),
+      );
+      final document = await _scanner.processImage(inputImage);
+      if (document.blocks.isNotEmpty) {
+        final rect = document.blocks.first.boundingBox;
+        _onRectDetected(rect);
+      } else {
+        _onRectLost();
+      }
+    } catch (_) {
+      // fallback to edge_detection, which only tells if a rectangle exists
+      _onRectLost();
+    }
+  }
+
+  Uint8List _concatenatePlanes(List<Plane> planes) {
+    final WriteBuffer allBytes = WriteBuffer();
+    for (final Plane plane in planes) {
+      allBytes.putUint8List(plane.bytes);
+    }
+    return allBytes.done().buffer.asUint8List();
+  }
+
+  void _onRectDetected(Rect rect) {
+    _detectedRect = rect;
+    _stabilityTimer ??= Timer(const Duration(seconds: 1), _startCountdown);
+  }
+
+  void _onRectLost() {
+    _detectedRect = null;
+    _stabilityTimer?.cancel();
+    _stabilityTimer = null;
+    _cancelCountdown();
+  }
+
+  void _startCountdown() {
+    if (_detectedRect == null || _countdown != null) return;
+    _countdown = 3;
+    _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_countdown == null) return;
+      setState(() => _countdown = _countdown! - 1);
+      if (_countdown == 0) {
+        timer.cancel();
+        _countdown = null;
+        _takePicture();
+      }
+    });
+  }
+
+  void _cancelCountdown() {
+    _countdownTimer?.cancel();
+    _countdownTimer = null;
+    if (_countdown != null) {
+      setState(() => _countdown = null);
+    }
+  }
+
+  Future<void> _takePicture() async {
+    if (_controller == null) return;
+    try {
+      final file = await _controller!.takePicture();
+      Rect? rect = _detectedRect;
+      XFile output = file;
+      if (rect != null) {
+        output = await _cropToRect(file, rect);
+      } else {
+        // try edge detection as fallback
+        final tempDir = await getTemporaryDirectory();
+        final path = p.join(tempDir.path, 'edge_${DateTime.now().millisecondsSinceEpoch}.jpg');
+        final detected = await EdgeDetection.detectEdge(file.path, path: path);
+        if (detected) {
+          output = XFile(path);
+        }
+      }
+      setState(() {
+        _capturedFile = output;
+      });
+      widget.onSaved(output);
+    } catch (e) {
+      debugPrint('Capture error: $e');
+    }
+  }
+
+  Future<XFile> _cropToRect(XFile file, Rect rect) async {
+    final bytes = await file.readAsBytes();
+    final original = img.decodeImage(bytes);
+    if (original == null) return file;
+    // rect is relative to image size from camera preview
+    final width = original.width;
+    final height = original.height;
+    final cropRect = Rect.fromLTWH(
+      max(0, rect.left).clamp(0, width.toDouble()),
+      max(0, rect.top).clamp(0, height.toDouble()),
+      min(rect.width, width.toDouble()),
+      min(rect.height, height.toDouble()),
+    );
+    final cropped = img.copyCrop(
+      original,
+      x: cropRect.left.round(),
+      y: cropRect.top.round(),
+      width: cropRect.width.round(),
+      height: cropRect.height.round(),
+    );
+    final tempDir = await getTemporaryDirectory();
+    final path =
+        p.join(tempDir.path, '${widget.purpose.name}_${DateTime.now().millisecondsSinceEpoch}.jpg');
+    final encoded = img.encodeJpg(cropped);
+    final fileOut = await File(path).writeAsBytes(encoded);
+    return XFile(fileOut.path);
+  }
+
+  void _retry() {
+    setState(() => _capturedFile = null);
+    _cancelCountdown();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title)),
+      body: !_initialized
+          ? const Center(child: CircularProgressIndicator())
+          : Stack(
+              children: [
+                if (_capturedFile == null)
+                  CameraPreview(_controller!),
+                if (_capturedFile == null) _buildOverlay(),
+                if (_capturedFile != null)
+                  Positioned.fill(
+                    child: Image.file(File(_capturedFile!.path), fit: BoxFit.cover),
+                  ),
+                if (_countdown != null)
+                  Center(
+                    child: Text(
+                      '$_countdown',
+                      style: const TextStyle(fontSize: 80, color: Colors.white),
+                    ),
+                  ),
+                Positioned(
+                  bottom: 32,
+                  left: 0,
+                  right: 0,
+                  child: _capturedFile == null
+                      ? Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Text(
+                              'Alinea el borde del documento dentro del marco',
+                              style: TextStyle(color: Colors.white),
+                            ),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                              onPressed: _takePicture,
+                              child: const Text('Capturar manualmente'),
+                            ),
+                          ],
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ],
+            ),
+      bottomNavigationBar: Row(
+        children: [
+          Expanded(
+            child: TextButton(
+              onPressed: () => Get.back(),
+              child: const Text('Volver'),
+            ),
+          ),
+          if (_capturedFile != null) ...[
+            Expanded(
+              child: TextButton(
+                onPressed: _retry,
+                child: const Text('Reintentar'),
+              ),
+            ),
+            Expanded(
+              child: TextButton(
+                onPressed: () => Get.toNamed(widget.nextRoute),
+                child: const Text('Siguiente'),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOverlay() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
+        // Determine rect for document ratio 1.586:1
+        final frameWidth = width * 0.9;
+        final frameHeight = frameWidth / 1.586;
+        final top = (height - frameHeight) / 2;
+        final left = (width - frameWidth) / 2;
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: Container(color: Colors.black45),
+            ),
+            Positioned(
+              top: top,
+              left: left,
+              width: frameWidth,
+              height: frameHeight,
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.white, width: 2),
+                  color: Colors.transparent,
+                ),
+              ),
+            ),
+            // Clear the inside of frame
+            Positioned(
+              top: top,
+              left: left,
+              width: frameWidth,
+              height: frameHeight,
+              child: ClipPath(
+                clipper: _RectClipper(),
+                child: Container(color: Colors.transparent),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _RectClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) => Path()..addRect(Rect.fromLTWH(0, 0, size.width, size.height));
+
+  @override
+  bool shouldReclip(covariant CustomClipper<Path> oldClipper) => false;
+}

--- a/lib/app/modules/loan_request/camera_utils.dart
+++ b/lib/app/modules/loan_request/camera_utils.dart
@@ -1,0 +1,15 @@
+import 'package:camera/camera.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+/// Requests camera permission and returns the back camera description.
+Future<CameraDescription> ensureCameraReady() async {
+  final status = await Permission.camera.request();
+  if (!status.isGranted) {
+    throw CameraException('PERMISSION_DENIED', 'Camera permission not granted');
+  }
+  final cameras = await availableCameras();
+  return cameras.firstWhere(
+    (c) => c.lensDirection == CameraLensDirection.back,
+    orElse: () => cameras.first,
+  );
+}

--- a/lib/app/modules/loan_request/capture_card_page.dart
+++ b/lib/app/modules/loan_request/capture_card_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+
+import 'auto_capture_screen.dart';
+import 'loan_request_provider.dart';
+import '../../routes/app_routes.dart';
+
+class CaptureCardPage extends ConsumerWidget {
+  const CaptureCardPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AutoCaptureScreen(
+      title: 'Foto de tarjeta',
+      purpose: CapturePurpose.cardFront,
+      nextRoute: AppRoutes.loanCaptureIneFront,
+      initialPath: ref.read(loanRequestProvider).cardFront,
+      onSaved: (file) =>
+          ref.read(loanRequestProvider.notifier).setCardFront(file.path),
+    );
+  }
+}

--- a/lib/app/modules/loan_request/capture_doc_page.dart
+++ b/lib/app/modules/loan_request/capture_doc_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+
+import 'auto_capture_screen.dart';
+import 'loan_request_provider.dart';
+import '../../routes/app_routes.dart';
+
+class CaptureDocPage extends ConsumerWidget {
+  const CaptureDocPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AutoCaptureScreen(
+      title: 'Foto de documento',
+      purpose: CapturePurpose.docPhoto,
+      nextRoute: AppRoutes.loanSign,
+      initialPath: ref.read(loanRequestProvider).docPhoto,
+      onSaved: (file) =>
+          ref.read(loanRequestProvider.notifier).setDocPhoto(file.path),
+    );
+  }
+}

--- a/lib/app/modules/loan_request/capture_ine_back_page.dart
+++ b/lib/app/modules/loan_request/capture_ine_back_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+
+import 'auto_capture_screen.dart';
+import 'loan_request_provider.dart';
+import '../../routes/app_routes.dart';
+
+class CaptureIneBackPage extends ConsumerWidget {
+  const CaptureIneBackPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AutoCaptureScreen(
+      title: 'INE – Reverso',
+      purpose: CapturePurpose.ineBack,
+      nextRoute: AppRoutes.loanCaptureDoc,
+      initialPath: ref.read(loanRequestProvider).ineBack,
+      onSaved: (file) =>
+          ref.read(loanRequestProvider.notifier).setIneBack(file.path),
+    );
+  }
+}

--- a/lib/app/modules/loan_request/capture_ine_front_page.dart
+++ b/lib/app/modules/loan_request/capture_ine_front_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+
+import 'auto_capture_screen.dart';
+import 'loan_request_provider.dart';
+import '../../routes/app_routes.dart';
+
+class CaptureIneFrontPage extends ConsumerWidget {
+  const CaptureIneFrontPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AutoCaptureScreen(
+      title: 'INE – Frente',
+      purpose: CapturePurpose.ineFront,
+      nextRoute: AppRoutes.loanCaptureIneBack,
+      initialPath: ref.read(loanRequestProvider).ineFront,
+      onSaved: (file) =>
+          ref.read(loanRequestProvider.notifier).setIneFront(file.path),
+    );
+  }
+}

--- a/lib/app/modules/loan_request/loan_request_provider.dart
+++ b/lib/app/modules/loan_request/loan_request_provider.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LoanRequestState {
+  final String? cardFront;
+  final String? ineFront;
+  final String? ineBack;
+  final String? docPhoto;
+  final String? signaturePngPath;
+
+  const LoanRequestState({
+    this.cardFront,
+    this.ineFront,
+    this.ineBack,
+    this.docPhoto,
+    this.signaturePngPath,
+  });
+
+  bool get isComplete =>
+      cardFront != null &&
+      cardFront!.isNotEmpty &&
+      ineFront != null &&
+      ineFront!.isNotEmpty &&
+      ineBack != null &&
+      ineBack!.isNotEmpty &&
+      docPhoto != null &&
+      docPhoto!.isNotEmpty &&
+      signaturePngPath != null &&
+      signaturePngPath!.isNotEmpty;
+
+  LoanRequestState copyWith({
+    String? cardFront,
+    String? ineFront,
+    String? ineBack,
+    String? docPhoto,
+    String? signaturePngPath,
+  }) {
+    return LoanRequestState(
+      cardFront: cardFront ?? this.cardFront,
+      ineFront: ineFront ?? this.ineFront,
+      ineBack: ineBack ?? this.ineBack,
+      docPhoto: docPhoto ?? this.docPhoto,
+      signaturePngPath: signaturePngPath ?? this.signaturePngPath,
+    );
+  }
+}
+
+class LoanRequestNotifier extends StateNotifier<LoanRequestState> {
+  LoanRequestNotifier() : super(const LoanRequestState()) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = LoanRequestState(
+      cardFront: prefs.getString('cardFront'),
+      ineFront: prefs.getString('ineFront'),
+      ineBack: prefs.getString('ineBack'),
+      docPhoto: prefs.getString('docPhoto'),
+      signaturePngPath: prefs.getString('signaturePng'),
+    );
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    Future<void> save(String key, String? value) async {
+      if (value == null || value.isEmpty) {
+        await prefs.remove(key);
+      } else {
+        await prefs.setString(key, value);
+      }
+    }
+
+    await save('cardFront', state.cardFront);
+    await save('ineFront', state.ineFront);
+    await save('ineBack', state.ineBack);
+    await save('docPhoto', state.docPhoto);
+    await save('signaturePng', state.signaturePngPath);
+  }
+
+  void setCardFront(String path) {
+    state = state.copyWith(cardFront: path);
+    _persist();
+  }
+
+  void setIneFront(String path) {
+    state = state.copyWith(ineFront: path);
+    _persist();
+  }
+
+  void setIneBack(String path) {
+    state = state.copyWith(ineBack: path);
+    _persist();
+  }
+
+  void setDocPhoto(String path) {
+    state = state.copyWith(docPhoto: path);
+    _persist();
+  }
+
+  void setSignaturePath(String path) {
+    state = state.copyWith(signaturePngPath: path);
+    _persist();
+  }
+
+  void clearSignature() {
+    state = state.copyWith(signaturePngPath: null);
+    _persist();
+  }
+
+  void clear() {
+    state = const LoanRequestState();
+    _persist();
+  }
+}
+
+final loanRequestProvider =
+    StateNotifierProvider<LoanRequestNotifier, LoanRequestState>(
+        (ref) => LoanRequestNotifier());

--- a/lib/app/modules/loan_request/loan_request_service.dart
+++ b/lib/app/modules/loan_request/loan_request_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:http/http.dart' as http;
+import 'package:uuid/uuid.dart';
+
+import 'loan_request_provider.dart';
+
+class LoanRequestService {
+  final http.Client _client;
+  LoanRequestService({http.Client? client}) : _client = client ?? http.Client();
+
+  Future<String> _fileToBase64(String path) async {
+    final bytes = await File(path).readAsBytes();
+    return base64Encode(bytes);
+  }
+
+  Future<void> submit(LoanRequestState state) async {
+    final payload = {
+      'cardFront': await _fileToBase64(state.cardFront!),
+      'ineFront': await _fileToBase64(state.ineFront!),
+      'ineBack': await _fileToBase64(state.ineBack!),
+      'docPhoto': await _fileToBase64(state.docPhoto!),
+      'signaturePng': await _fileToBase64(state.signaturePngPath!),
+      'deviceUuid': const Uuid().v4(),
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+
+    final response = await _client.post(
+      Uri.parse('https://api.ejemplo.com/loan/request'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException('HTTP ${response.statusCode}');
+    }
+  }
+}
+
+
+final loanRequestServiceProvider = Provider((ref) => LoanRequestService());

--- a/lib/app/modules/loan_request/review_page.dart
+++ b/lib/app/modules/loan_request/review_page.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+
+import '../../routes/app_routes.dart';
+import 'loan_request_provider.dart';
+import 'loan_request_service.dart';
+
+class ReviewPage extends ConsumerStatefulWidget {
+  const ReviewPage({super.key});
+
+  @override
+  ConsumerState<ReviewPage> createState() => _ReviewPageState();
+}
+
+class _ReviewPageState extends ConsumerState<ReviewPage> {
+  bool _sending = false;
+
+  Future<void> _submit() async {
+    final state = ref.read(loanRequestProvider);
+    final service = ref.read(loanRequestServiceProvider);
+    setState(() => _sending = true);
+    try {
+      await service.submit(state);
+      Get.snackbar('Éxito', 'Solicitud enviada');
+      ref.read(loanRequestProvider.notifier).clear();
+      Get.offAllNamed(AppRoutes.loanRequestStart);
+    } catch (e) {
+      Get.snackbar('Error', e.toString());
+    } finally {
+      if (mounted) setState(() => _sending = false);
+    }
+  }
+
+  Widget _buildItem(String? path, String label, VoidCallback onEdit) {
+    if (path == null) return const SizedBox.shrink();
+    return ListTile(
+      leading: Image.file(File(path), width: 80, height: 80, fit: BoxFit.cover),
+      title: Text(label),
+      trailing: TextButton(onPressed: onEdit, child: const Text('Editar')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(loanRequestProvider);
+    return Stack(
+      children: [
+        Scaffold(
+          appBar: AppBar(title: const Text('Revisión')),
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                _buildItem(state.cardFront, 'Tarjeta', () => Get.toNamed(AppRoutes.loanCaptureCard)),
+                _buildItem(state.ineFront, 'INE Frente', () => Get.toNamed(AppRoutes.loanCaptureIneFront)),
+                _buildItem(state.ineBack, 'INE Reverso', () => Get.toNamed(AppRoutes.loanCaptureIneBack)),
+                _buildItem(state.docPhoto, 'Documento', () => Get.toNamed(AppRoutes.loanCaptureDoc)),
+                _buildItem(state.signaturePngPath, 'Firma', () => Get.toNamed(AppRoutes.loanSign)),
+                const SizedBox(height: 20),
+                ElevatedButton(
+                  onPressed: state.isComplete && !_sending ? _submit : null,
+                  child: const Text('Enviar solicitud'),
+                ),
+              ],
+            ),
+          ),
+          bottomNavigationBar: Row(
+            children: [
+              Expanded(
+                child: TextButton(
+                  onPressed: () => Get.back(),
+                  child: const Text('Volver'),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (_sending)
+          Container(
+            color: Colors.black45,
+            child: const Center(child: CircularProgressIndicator()),
+          ),
+      ],
+    );
+  }
+}
+

--- a/lib/app/modules/loan_request/sign_page.dart
+++ b/lib/app/modules/loan_request/sign_page.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:signature/signature.dart';
+
+import 'loan_request_provider.dart';
+import '../../routes/app_routes.dart';
+
+class SignPage extends ConsumerStatefulWidget {
+  const SignPage({super.key});
+
+  @override
+  ConsumerState<SignPage> createState() => _SignPageState();
+}
+
+class _SignPageState extends ConsumerState<SignPage> {
+  final SignatureController _controller =
+      SignatureController(penColor: Colors.black, penStrokeWidth: 3);
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    _controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    SystemChrome.setPreferredOrientations(DeviceOrientation.values);
+    super.dispose();
+  }
+
+  Future<void> _saveAndContinue() async {
+    if (_controller.isEmpty) return;
+    try {
+      final bytes = await _controller.toPngBytes(
+        backgroundColor: Colors.white,
+        height: 300,
+        width: 1000,
+      );
+      if (bytes == null) return;
+      final dir = await getTemporaryDirectory();
+      final path =
+          p.join(dir.path, 'sign_${DateTime.now().millisecondsSinceEpoch}.png');
+      final file = File(path);
+      await file.writeAsBytes(bytes);
+      ref.read(loanRequestProvider.notifier).setSignaturePath(path);
+      Get.toNamed(AppRoutes.loanReview);
+    } catch (e) {
+      debugPrint('Signature error: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Firma')),
+      body: Column(
+        children: [
+          Expanded(
+            child: Container(
+              color: Colors.white,
+              child: Signature(
+                controller: _controller,
+                backgroundColor: Colors.white,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      _controller.clear();
+                      ref
+                          .read(loanRequestProvider.notifier)
+                          .clearSignature();
+                    },
+                    child: const Text('Limpiar'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _controller.isEmpty
+                        ? null
+                        : () {
+                            _controller.undo();
+                          },
+                    child: const Text('Deshacer'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _saveAndContinue,
+                    child: const Text('Guardar y continuar'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: Row(
+        children: [
+          Expanded(
+            child: TextButton(
+              onPressed: () => Get.back(),
+              child: const Text('Volver'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/modules/loan_request/start_page.dart
+++ b/lib/app/modules/loan_request/start_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../routes/app_routes.dart';
+
+class LoanRequestStartPage extends StatelessWidget {
+  const LoanRequestStartPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Solicitud de préstamo')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => Get.toNamed(AppRoutes.loanCaptureCard),
+          child: const Text('Solicitar préstamos'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -6,6 +6,13 @@ import '../modules/onboarding/onboarding_binding.dart';
 import '../modules/onboarding/onboarding_view.dart';
 import '../modules/home/home_binding.dart';
 import '../modules/home/home_view.dart';
+import '../modules/loan_request/start_page.dart';
+import '../modules/loan_request/capture_card_page.dart';
+import '../modules/loan_request/capture_ine_front_page.dart';
+import '../modules/loan_request/capture_ine_back_page.dart';
+import '../modules/loan_request/capture_doc_page.dart';
+import '../modules/loan_request/sign_page.dart';
+import '../modules/loan_request/review_page.dart';
 import '../routes/app_routes.dart';
 
 class AppPages {
@@ -34,6 +41,34 @@ class AppPages {
       name: AppRoutes.home,
       page: () => HomeView(),
       binding: HomeBinding(),
+    ),
+    GetPage(
+      name: AppRoutes.loanRequestStart,
+      page: () => const LoanRequestStartPage(),
+    ),
+    GetPage(
+      name: AppRoutes.loanCaptureCard,
+      page: () => const CaptureCardPage(),
+    ),
+    GetPage(
+      name: AppRoutes.loanCaptureIneFront,
+      page: () => const CaptureIneFrontPage(),
+    ),
+    GetPage(
+      name: AppRoutes.loanCaptureIneBack,
+      page: () => const CaptureIneBackPage(),
+    ),
+    GetPage(
+      name: AppRoutes.loanCaptureDoc,
+      page: () => const CaptureDocPage(),
+    ),
+    GetPage(
+      name: AppRoutes.loanSign,
+      page: () => const SignPage(),
+    ),
+    GetPage(
+      name: AppRoutes.loanReview,
+      page: () => const ReviewPage(),
     ),
   ];
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -4,4 +4,12 @@ class AppRoutes {
   static const login = '/login';
   static const register = '/register';
   static const home = '/home';
+
+  static const loanRequestStart = '/loan/request/start';
+  static const loanCaptureCard = '/loan/request/capture-card';
+  static const loanCaptureIneFront = '/loan/request/capture-ine-front';
+  static const loanCaptureIneBack = '/loan/request/capture-ine-back';
+  static const loanCaptureDoc = '/loan/request/capture-doc';
+  static const loanSign = '/loan/request/sign';
+  static const loanReview = '/loan/request/review';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'app/routes/app_pages.dart';
 import 'app/routes/app_routes.dart';
 
 void main() {
   runApp(
-    GetMaterialApp(
-      title: "CrediApp",
-      initialRoute: AppRoutes.initial,
-      getPages: AppPages.routes,
-      debugShowCheckedModeBanner: false,
+    ProviderScope(
+      child: GetMaterialApp(
+        title: "CrediApp",
+        initialRoute: AppRoutes.initial,
+        getPages: AppPages.routes,
+        debugShowCheckedModeBanner: false,
+      ),
     ),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,15 @@ dependencies:
   flutter_riverpod: ^2.6.1
   http: ^1.4.0
   lottie: ^3.3.1
+  camera: ^0.10.5+2
+  permission_handler: ^11.0.1
+  edge_detection: ^1.1.5
+  google_mlkit_document_scanner: ^0.3.0
+  image: ^4.2.2
+  signature: ^5.5.0
+  path_provider: ^2.1.3
+  path: ^1.9.0
+  shared_preferences: ^2.3.2
   
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- persist captured file paths with SharedPreferences to restore loan request progress
- pass saved paths into reusable `AutoCaptureScreen` and include a dedicated `Volver` control
- allow backing out from signature screen and update `pubspec.yaml` with `shared_preferences`
- document project requirements, loan-request flow, permissions, and build steps in the README

## Testing
- `dart format README.md` *(fails: command not found: dart)*
- `flutter analyze` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6896dbde5094832b9ecc260645ed965e