### PR TITLE
feat: add multi-document capture for loan

### DIFF
--- a/lib/app/modules/home/widgets/home_request_loan_content.dart
+++ b/lib/app/modules/home/widgets/home_request_loan_content.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 import 'dart:typed_data';
+import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
-import 'package:camera/camera.dart'; // Para XFile
-import 'loan_camera_page.dart'; // <-- ajusta la ruta si la guardas en otro folder
 import 'package:permission_handler/permission_handler.dart';
+import 'loan_camera_page.dart';
 
 class HomeRequestLoanContent extends StatefulWidget {
   final dynamic controller;
@@ -15,28 +15,43 @@ class HomeRequestLoanContent extends StatefulWidget {
 
 class _HomeRequestLoanContentState extends State<HomeRequestLoanContent> {
   final loanAmountController = TextEditingController();
-  String selectedTerm = "6 meses";
+  String selectedTerm = '6 meses';
 
-  // NUEVO: foto capturada
-  XFile? _loanPhoto;
-  Uint8List? _loanPhotoBytes;
-  String? _loanPhotoB64;
+  final Map<LoanDocKind, XFile?> _photos = {
+    for (var k in LoanDocKind.values) k: null,
+  };
+  final Map<LoanDocKind, Uint8List?> _photoBytes = {
+    for (var k in LoanDocKind.values) k: null,
+  };
+  final Map<LoanDocKind, String?> _photoB64 = {
+    for (var k in LoanDocKind.values) k: null,
+  };
+
+  bool get _allCaptured =>
+      LoanDocKind.values.every((k) => _photos[k] != null);
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context).colorScheme;
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text("Solicitar préstamo",
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onSurface)),
+          Text(
+            'Solicitar préstamo',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: theme.onSurface,
+            ),
+          ),
           const SizedBox(height: 16),
 
           // Crédito disponible
           Container(
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primaryContainer,
+              color: theme.primaryContainer,
               borderRadius: BorderRadius.circular(12),
             ),
             padding: const EdgeInsets.all(12),
@@ -46,20 +61,40 @@ class _HomeRequestLoanContentState extends State<HomeRequestLoanContent> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    Text("Crédito disponible",
-                        style: TextStyle(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurfaceVariant)),
-                    Text("\$15,000.00",
-                        style: TextStyle(fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onSurfaceVariant)),
+                    Text(
+                      'Crédito disponible',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w500,
+                        color: theme.onSurfaceVariant,
+                      ),
+                    ),
+                    Text(
+                      '\$15,000.00',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: theme.onSurfaceVariant,
+                      ),
+                    ),
                   ],
                 ),
                 const SizedBox(height: 4),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    Text("Tasa de interés",
-                        style: TextStyle(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface)),
-                    Text("12.5%",
-                        style: TextStyle(fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onSurface)),
+                    Text(
+                      'Tasa de interés',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w500,
+                        color: theme.onSurface,
+                      ),
+                    ),
+                    Text(
+                      '12.5%',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: theme.onSurface,
+                      ),
+                    ),
                   ],
                 ),
               ],
@@ -67,152 +102,272 @@ class _HomeRequestLoanContentState extends State<HomeRequestLoanContent> {
           ),
 
           // Monto del préstamo
-          Text("Monto del préstamo",
-              style: TextStyle(fontSize: 12, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface)),
+          Text(
+            'Monto del préstamo',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: theme.onSurface,
+            ),
+          ),
           const SizedBox(height: 4),
           Stack(
             alignment: Alignment.centerLeft,
             children: [
               const Padding(
                 padding: EdgeInsets.only(left: 12),
-                child: Text("\$",
-                    style: TextStyle(color: Colors.grey, fontSize: 16)),
+                child: Text(
+                  '\$',
+                  style: TextStyle(color: Colors.grey, fontSize: 16),
+                ),
               ),
               TextField(
                 controller: loanAmountController,
                 keyboardType: TextInputType.number,
-                autofillHints: const [], // ← desactiva autofill para este campo
+                autofillHints: const [],
                 decoration: InputDecoration(
-                  contentPadding: const EdgeInsets.symmetric(vertical: 12, horizontal: 24),
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
-                  hintText: "0.00",
+                  contentPadding:
+                      const EdgeInsets.symmetric(vertical: 12, horizontal: 24),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  hintText: '0.00',
                 ),
               ),
             ],
           ),
           const SizedBox(height: 4),
-          Text("Mínimo: \$1,000.00 - Máximo: \$15,000.00",
-              style: TextStyle(fontSize: 10, color: Theme.of(context).colorScheme.onSurfaceVariant)),
+          Text(
+            'Mínimo: \$1,000.00 - Máximo: \$15,000.00',
+            style: TextStyle(fontSize: 10, color: theme.onSurfaceVariant),
+          ),
           const SizedBox(height: 16),
 
           // Plazo
-          Text("Plazo",
-              style: TextStyle(fontSize: 12, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface)),
+          Text(
+            'Plazo',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: theme.onSurface,
+            ),
+          ),
           const SizedBox(height: 4),
           DropdownButtonFormField<String>(
             value: selectedTerm,
-            items: ["3 meses", "6 meses", "9 meses", "12 meses"]
+            items: ['3 meses', '6 meses', '9 meses', '12 meses']
                 .map((e) => DropdownMenuItem(value: e, child: Text(e)))
                 .toList(),
-            onChanged: (val) {
-              setState(() {
-                selectedTerm = val!;
-              });
-            },
+            onChanged: (val) => setState(() => selectedTerm = val ?? selectedTerm),
             decoration: InputDecoration(
-              border:
-                  OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
             ),
           ),
           const SizedBox(height: 16),
 
-          // Resumen préstamo
-          Container(
-            decoration: BoxDecoration(
-              color: Colors.white,
-              border: Border.all(color: Colors.grey.shade200),
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: const [
-                BoxShadow(color: Colors.black12, blurRadius: 2, offset: Offset(0, 1))
-              ],
-            ),
-            padding: const EdgeInsets.all(12),
-            margin: const EdgeInsets.only(bottom: 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text("Resumen del préstamo",
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14, color: Theme.of(context).colorScheme.onSurface)),
-                const SizedBox(height: 8),
-                _summaryRow("Monto solicitado", "\$10,000.00"),
-                _summaryRow("Tasa de interés", "12.5%"),
-                _summaryRow("Plazo", selectedTerm),
-                const Divider(),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text("Pago mensual estimado",
-                        style: TextStyle(fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onSurface)),
-                    Text("\$1,791.67",
-                        style: TextStyle(fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onSurface)),
-                  ],
-                ),
+          _buildDocCard(LoanDocKind.ineFront),
+          const SizedBox(height: 12),
+          _buildDocCard(LoanDocKind.ineBack),
+          const SizedBox(height: 12),
+          _buildDocCard(LoanDocKind.comprobante),
+          const SizedBox(height: 16),
 
-                // NUEVO: miniatura si hay foto
-                if (_loanPhotoBytes != null) ...[
-                  const SizedBox(height: 12),
-                  Text("Documento capturado",
-                      style: TextStyle(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface)),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: Image.memory(
-                          _loanPhotoBytes!,
-                          width: 96,
-                          height: 96,
-                          fit: BoxFit.cover,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Text(
-                          _loanPhoto?.name ?? 'imagen.jpg',
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
-                        ),
-                      ),
-                      IconButton(
-                        tooltip: 'Quitar',
-                        onPressed: () {
-                          setState(() {
-                            _loanPhoto = null;
-                            _loanPhotoBytes = null;
-                            _loanPhotoB64 = null;
-                          });
-                        },
-                        icon: const Icon(Icons.delete_outline),
-                      ),
-                    ],
-                  ),
-                ],
-              ],
-            ),
-          ),
+          _buildSummary(theme),
 
-          // Botón -> abre cámara
+          // Enviar solicitud
           SizedBox(
             width: double.infinity,
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                backgroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
+                backgroundColor: theme.onPrimaryContainer,
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12)),
+                  borderRadius: BorderRadius.circular(12),
+                ),
               ),
-              onPressed: _onRequestLoanPressed,
-              child: Text("Solicitar préstamo",
-                  style: TextStyle(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.primaryContainer)),
+              onPressed: _allCaptured ? _submitLoan : null,
+              child: Text(
+                'Enviar solicitud',
+                style: TextStyle(
+                  fontWeight: FontWeight.w500,
+                  color: theme.primaryContainer,
+                ),
+              ),
             ),
-          )
+          ),
         ],
       ),
     );
   }
 
-  Future<void> _onRequestLoanPressed() async {
+  Widget _buildDocCard(LoanDocKind kind) {
+    final theme = Theme.of(context).colorScheme;
+    final photo = _photos[kind];
+    final bytes = _photoBytes[kind];
+    final completed = photo != null;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  kind.title,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: theme.onSurface,
+                  ),
+                ),
+                _buildBadge(completed),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (bytes != null)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.memory(
+                  bytes,
+                  width: double.infinity,
+                  height: 120,
+                  fit: BoxFit.cover,
+                ),
+              )
+            else
+              Text(
+                kind.helper,
+                style: TextStyle(color: theme.onSurfaceVariant, fontSize: 12),
+              ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: () => _captureDoc(kind),
+                  child: Text(completed ? 'Repetir' : 'Tomar'),
+                ),
+                const SizedBox(width: 8),
+                OutlinedButton(
+                  onPressed: completed ? () => _removeDoc(kind) : null,
+                  child: const Text('Quitar'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBadge(bool done) {
+    final theme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: done ? theme.secondaryContainer : theme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        done ? 'Completado' : 'Pendiente',
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          color: done ? theme.onSecondaryContainer : theme.onErrorContainer,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummary(ColorScheme theme) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: Colors.grey.shade200),
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: const [
+          BoxShadow(color: Colors.black12, blurRadius: 2, offset: Offset(0, 1)),
+        ],
+      ),
+      padding: const EdgeInsets.all(12),
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Resumen del préstamo',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 14,
+              color: theme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 8),
+          _summaryRow('Monto solicitado', '\$10,000.00'),
+          _summaryRow('Tasa de interés', '12.5%'),
+          _summaryRow('Plazo', selectedTerm),
+          const Divider(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Pago mensual estimado',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  color: theme.onSurface,
+                ),
+              ),
+              Text(
+                '\$1,791.67',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  color: theme.onSurface,
+                ),
+              ),
+            ],
+          ),
+          for (final kind in LoanDocKind.values)
+            if (_photoBytes[kind] != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                kind.title,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: theme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Image.memory(
+                      _photoBytes[kind]!,
+                      width: 96,
+                      height: 96,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      _photos[kind]!.name,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(color: theme.onSurfaceVariant),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _captureDoc(LoanDocKind kind) async {
     final status = await Permission.camera.request();
     if (!status.isGranted) {
       if (mounted) {
@@ -223,31 +378,57 @@ class _HomeRequestLoanContentState extends State<HomeRequestLoanContent> {
       return;
     }
 
-    final photo = await Navigator.push(
+    final photo = await Navigator.push<XFile?>(
       context,
-      MaterialPageRoute(builder: (_) => const LoanCameraPage()),
+      MaterialPageRoute(builder: (_) => LoanCameraPage(kind: kind)),
     );
 
     if (!mounted || photo == null) return;
 
     final bytes = await photo.readAsBytes();
     setState(() {
-      _loanPhoto = photo;
-      _loanPhotoBytes = bytes;
-      _loanPhotoB64 = base64Encode(bytes);
+      _photos[kind] = photo;
+      _photoBytes[kind] = bytes;
+      _photoB64[kind] = base64Encode(bytes);
     });
   }
 
+  void _removeDoc(LoanDocKind kind) {
+    setState(() {
+      _photos[kind] = null;
+      _photoBytes[kind] = null;
+      _photoB64[kind] = null;
+    });
+  }
+
+  void _submitLoan() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Solicitud enviada')),
+    );
+  }
+
   Widget _summaryRow(String label, String value) {
+    final theme = Theme.of(context).colorScheme;
     return Padding(
       padding: const EdgeInsets.only(bottom: 4),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(label, style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant, fontSize: 12)),
-          Text(value, style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface)),
+          Text(
+            label,
+            style: TextStyle(
+              color: theme.onSurfaceVariant,
+              fontSize: 12,
+            ),
+          ),
+          Text(
+            value,
+            style: TextStyle(fontSize: 12, color: theme.onSurface),
+          ),
         ],
       ),
     );
   }
 }
+

--- a/lib/app/modules/home/widgets/loan_camera_page.dart
+++ b/lib/app/modules/home/widgets/loan_camera_page.dart
@@ -3,22 +3,74 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+// Tipos de documento requeridos
+enum LoanDocKind { ineFront, ineBack, comprobante }
+
+extension LoanDocKindX on LoanDocKind {
+  String get title {
+    switch (this) {
+      case LoanDocKind.ineFront:
+        return 'INE - Frente';
+      case LoanDocKind.ineBack:
+        return 'INE - Reverso';
+      case LoanDocKind.comprobante:
+        return 'Documento';
+    }
+  }
+
+  String get helper {
+    switch (this) {
+      case LoanDocKind.ineFront:
+        return 'Alinea el frente de tu INE dentro del marco';
+      case LoanDocKind.ineBack:
+        return 'Alinea el reverso de tu INE dentro del marco';
+      case LoanDocKind.comprobante:
+        return 'Alinea el documento dentro del marco';
+    }
+  }
+
+  double get aspectRatio {
+    switch (this) {
+      case LoanDocKind.ineFront:
+      case LoanDocKind.ineBack:
+        return 1.586; // 85.6x54mm
+      case LoanDocKind.comprobante:
+        return 1.414; // √2
+    }
+  }
+}
+
 class LoanCameraPage extends StatefulWidget {
-  const LoanCameraPage({super.key});
+  final LoanDocKind kind;
+  const LoanCameraPage({super.key, required this.kind});
 
   @override
   State<LoanCameraPage> createState() => _LoanCameraPageState();
 }
 
 class _LoanCameraPageState extends State<LoanCameraPage>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, SingleTickerProviderStateMixin {
   CameraController? _controller;
   Future<void>? _initFuture;
+  late final AnimationController _shutterCtrl;
+  late final Animation<double> _shutterScale;
+  bool _flashVisible = false;
+  bool _torchOn = false;
+
+  bool get _hasTorch => _controller?.description?.hasFlash ?? false;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    _shutterCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _shutterScale = Tween(begin: 1.0, end: 0.85).animate(
+      CurvedAnimation(parent: _shutterCtrl, curve: Curves.easeOut),
+    );
     _initCamera();
   }
 
@@ -53,8 +105,10 @@ class _LoanCameraPageState extends State<LoanCameraPage>
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     _controller?.dispose();
+    _shutterCtrl.dispose();
     super.dispose();
   }
 
@@ -70,7 +124,7 @@ class _LoanCameraPageState extends State<LoanCameraPage>
     }
   }
 
-  Future<void> _takePhoto() async {
+  Future<void> _capturePhoto() async {
     final controller = _controller;
     if (controller == null) return;
 
@@ -79,9 +133,10 @@ class _LoanCameraPageState extends State<LoanCameraPage>
       if (!controller.value.isInitialized || controller.value.isTakingPicture) {
         return;
       }
+      _playShutterFx();
       final XFile file = await controller.takePicture();
       if (!mounted) return;
-      Navigator.pop(context, file); // devolvemos la foto
+      Navigator.pop(context, file);
     } catch (e) {
       debugPrint('Error al tomar foto: $e');
       if (mounted) {
@@ -92,10 +147,31 @@ class _LoanCameraPageState extends State<LoanCameraPage>
     }
   }
 
+  void _playShutterFx() {
+    HapticFeedback.lightImpact();
+    _shutterCtrl.forward(from: 0).then((_) => _shutterCtrl.reverse());
+    setState(() => _flashVisible = true);
+    Future.delayed(const Duration(milliseconds: 200), () {
+      if (mounted) setState(() => _flashVisible = false);
+    });
+  }
+
+  Future<void> _toggleTorch() async {
+    final controller = _controller;
+    if (controller == null) return;
+    _torchOn = !_torchOn;
+    try {
+      await controller.setFlashMode(
+          _torchOn ? FlashMode.torch : FlashMode.off);
+      setState(() {});
+    } catch (_) {
+      _torchOn = false;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = _controller;
-
     return Scaffold(
       backgroundColor: Colors.black,
       body: SafeArea(
@@ -107,15 +183,19 @@ class _LoanCameraPageState extends State<LoanCameraPage>
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.done &&
                       controller.value.isInitialized) {
-                    return Center(child: CameraPreview(controller));
+                    return CameraPreview(controller);
                   }
                   return const Center(child: CircularProgressIndicator());
                 },
               )
             else
               const Center(child: CircularProgressIndicator()),
-
-            // Cancelar
+            _buildOverlay(),
+            AnimatedOpacity(
+              opacity: _flashVisible ? 1 : 0,
+              duration: const Duration(milliseconds: 200),
+              child: Container(color: Colors.white),
+            ),
             Positioned(
               top: 12,
               left: 12,
@@ -126,23 +206,44 @@ class _LoanCameraPageState extends State<LoanCameraPage>
                 onPressed: () => Navigator.pop(context, null),
               ),
             ),
-
-            // Tomar foto
             Positioned(
               bottom: 24,
               left: 0,
               right: 0,
-              child: Center(
-                child: ElevatedButton.icon(
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                    backgroundColor: Colors.white,
-                    foregroundColor: Colors.black,
-                  ),
-                  icon: const Icon(Icons.camera_alt),
-                  label: const Text('Tomar foto'),
-                  onPressed: _takePhoto,
+              child: SizedBox(
+                height: 100,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    ScaleTransition(
+                      scale: _shutterScale,
+                      child: GestureDetector(
+                        onTap: _capturePhoto,
+                        child: Container(
+                          width: 72,
+                          height: 72,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(color: Colors.white, width: 4),
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (_hasTorch)
+                      Positioned(
+                        right: 32,
+                        child: IconButton(
+                          color: Colors.white,
+                          iconSize: 32,
+                          icon: Icon(
+                            _torchOn
+                                ? Icons.flashlight_on
+                                : Icons.flashlight_off,
+                          ),
+                          onPressed: _toggleTorch,
+                        ),
+                      ),
+                  ],
                 ),
               ),
             ),
@@ -151,4 +252,70 @@ class _LoanCameraPageState extends State<LoanCameraPage>
       ),
     );
   }
+
+  Widget _buildOverlay() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.biggest;
+        final ratio = widget.kind.aspectRatio;
+        double width = size.width - 32;
+        double height = width / ratio;
+        if (height > size.height - 120) {
+          height = size.height - 120;
+          width = height * ratio;
+        }
+        final rect = Rect.fromCenter(
+          center: size.center(Offset.zero),
+          width: width,
+          height: height,
+        );
+        return Stack(
+          children: [
+            CustomPaint(size: size, painter: _OverlayPainter(rect)),
+            Positioned.fromRect(
+              rect: rect,
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.white, width: 2),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+            ),
+            Positioned(
+              bottom: 32,
+              left: 0,
+              right: 0,
+              child: Text(
+                widget.kind.helper,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
 }
+
+class _OverlayPainter extends CustomPainter {
+  final Rect hole;
+  _OverlayPainter(this.hole);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = Colors.black45;
+    final overlay = Path()..addRect(Rect.fromLTWH(0, 0, size.width, size.height));
+    final cutout = Path()
+      ..addRRect(RRect.fromRectAndRadius(hole, const Radius.circular(16)));
+    canvas.drawPath(Path.combine(PathOperation.difference, overlay, cutout), paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _OverlayPainter oldDelegate) =>
+      oldDelegate.hole != hole;
+}
+


### PR DESCRIPTION
## Summary
- add loan document enum and state to track INE front/back and generic document
- build guided camera page with overlay, torch toggle, and shutter animation
- expand loan request UI to manage three document cards and disable submit until all captured

## Testing
- `flutter format lib/app/modules/home/widgets/home_request_loan_content.dart lib/app/modules/home/widgets/loan_camera_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79b946680832bb0810d1a68835310